### PR TITLE
Fix install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively, do one of the following:
 Using `go install`:
 
 ```bash
- go install https://github.com/holgerjh/genjsonschema-cli
+ go install github.com/holgerjh/genjsonschema-cli@latest
 ```
 
 Manually (Linux):


### PR DESCRIPTION
```
% go install https://github.com/holgerjh/genjsonschema-cli
malformed import path "https:/github.com/holgerjh/genjsonschema-cli": invalid char ':'
```

I tried the installation command listed in `README.md`.
However, it failed with the above error.
Therefore, I fix this command.